### PR TITLE
feat: load objects with primary key

### DIFF
--- a/src/CsvFileStorage.php
+++ b/src/CsvFileStorage.php
@@ -265,7 +265,8 @@ final class CsvFileStorage extends AbstractStorage implements Countable
             };
         }
         $item = new Item($obj);
-        $key = new ItemKey(++$this->lineNo);
+        $keyVal = method_exists($obj, "getPrimaryKey") === true ? $obj->getPrimaryKey() : ++$this->lineNo;
+        $key = new ItemKey($keyVal);
         $this->storeByKey($key, $item);
     }
 

--- a/tests/__fakes__/FakeValueObjectWithPrimaryKey.php
+++ b/tests/__fakes__/FakeValueObjectWithPrimaryKey.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpolar\CsvFileStorage\Tests\Fakes;
+
+final class FakeValueObjectWithPrimaryKey
+{
+    public string $id;
+    public function __construct(
+        public string $title = "Add a fake model",
+        public string $myInput = "what",
+        public int $myInt = 0,
+        public bool $myBool = false,
+        public ?string $myNull = null,
+        public float $myFloat = 1e1,
+    ) {
+    }
+
+    public function equals(self $other): bool
+    {
+        return $this->title === $other->title &&
+            $this->myInput === $other->myInput;
+    }
+
+    public function withPrimaryKey(string $id): self
+    {
+        $copy = clone $this;
+        $copy->id = $id;
+        return $copy;
+    }
+
+    public function getPrimaryKey(): string
+    {
+        return $this->id;
+    }
+}

--- a/tests/__fakes__/object-with-pkey.csv
+++ b/tests/__fakes__/object-with-pkey.csv
@@ -1,0 +1,2 @@
+id,title,myInput,myInt,myBool,myNull,myFloat
+123,"some title","some value",,,,1.0


### PR DESCRIPTION
Objects will now be stored with the primary key as the key in storage.  The object must have the `getPrimaryKey` method.  A future release will require objects to implement an interface instead of duck-typing.